### PR TITLE
chore: initialize devicons plugin

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/devicons.lua
+++ b/private_dot_config/nvim/lua/user/plugins/devicons.lua
@@ -4,7 +4,7 @@ local M = {
 }
 
 function M.config()
-  require "nvim-web-devicons"
+  require('nvim-web-devicons').setup{}
 end
 
 return M


### PR DESCRIPTION
## Summary
- initialize nvim-web-devicons plugin with default setup

## Testing
- `luac -p private_dot_config/nvim/lua/user/plugins/devicons.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a13cf4fdd4832eaec7d0408c438a8d