### PR TITLE
feat: add cmp plugin dependencies and fix Lua label

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/cmp.lua
+++ b/private_dot_config/nvim/lua/user/plugins/cmp.lua
@@ -39,6 +39,15 @@ local M = {
       "hrsh7th/cmp-nvim-lua", -- Provides Neovim Lua API completions.
       -- This plugin is always loaded, no specific event required.
     },
+    {
+      "tzachar/cmp-tabnine", -- Tabnine completion source for nvim-cmp.
+      build = "./install.sh",
+      event = "InsertEnter",
+    },
+    {
+      "hrsh7th/cmp-calc", -- Calculator completion source for nvim-cmp.
+      event = "InsertEnter",
+    },
   },
 }
 
@@ -120,7 +129,7 @@ function M.config()
         vim_item.kind = icons.kind[vim_item.kind]
         vim_item.menu = ({
           nvim_lsp = "[LSP]",
-          nvim_lua = "LUA]",
+          nvim_lua = "[Lua]",
           luasnip = "[LuaSnip",
           buffer = "[File]",
           path = "[Path]",


### PR DESCRIPTION
## Summary
- add cmp-tabnine and calc completion sources to plugin dependencies
- fix Lua display label in the completion menu

## Testing
- `luac -p private_dot_config/nvim/lua/user/plugins/cmp.lua` *(fails: command not found)*
- `nvim --headless +qa` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17d2b738c832e9c419e9554b9f6a0