### PR TITLE
Refine Tip.nvim configuration

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/tip.lua
+++ b/private_dot_config/nvim/lua/user/plugins/tip.lua
@@ -1,20 +1,26 @@
+---@type LazyPluginSpec
 local M = {
   "TobinPalmer/Tip.nvim",
   event = "VimEnter",
   dependencies = {
     "nvim-lua/plenary.nvim",
-    "rcarriga/nvim-notify"
+    "rcarriga/nvim-notify",
   },
-}
 
-function M.init()
-  require("tip").setup {
-      seconds = 8,
-      title = "Tip!",
-      -- url = "https://www.vimiscool.tech/neotip",
-      url = "https://vtip.43z.one", -- Or https://vimiscool.tech/neotip
-    }
-    vim.notify = require("notify") --TODO: Put 'notify' in a better location. Make its own file?
-  end
+  -- Configuration values passed to Tip.nvim when it initializes.
+  opts = {
+    seconds = 9, -- Show the floating tip slightly longer than the default.
+    title = "Tip!", -- Title displayed in the notification window.
+    url = "https://vtip.43z.one", -- Source for the rotating tip content.
+  },
+
+  -- Runs after the plugin is loaded so we can configure it and hook into nvim-notify.
+  config = function(_, opts)
+    require("tip").setup(opts)
+
+    -- Replace the default notification handler with nvim-notify so tips look nicer.
+    vim.notify = require("notify")
+  end,
+}
 
 return M


### PR DESCRIPTION
## Summary
- convert Tip.nvim plugin spec to use Lazy's opts/config pattern for easier maintenance
- extend the notification display to nine seconds and document the configuration with helpful comments
- ensure nvim-notify is wired up during plugin configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcaabd7e4832eb0e2c19e0469f770