### PR TITLE
Refresh nvim-cmp configuration

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/cmp.lua
+++ b/private_dot_config/nvim/lua/user/plugins/cmp.lua
@@ -1,106 +1,82 @@
 local M = {
-  "hrsh7th/nvim-cmp", -- Core completion engine for Neovim, provides autocomplete functionality.
-
-  -- Triggers the plugin's loading when entering insert mode.
-  event = "InsertEnter",
-
-  -- List of plugins that nvim-cmp depends on for providing various completions.
+  "hrsh7th/nvim-cmp",
+  event = { "InsertEnter", "CmdlineEnter" },
   dependencies = {
+    "hrsh7th/cmp-nvim-lsp",
+    "hrsh7th/cmp-emoji",
+    "hrsh7th/cmp-buffer",
+    "hrsh7th/cmp-path",
+    "hrsh7th/cmp-cmdline",
+    "saadparwaiz1/cmp_luasnip",
+    "hrsh7th/cmp-nvim-lua",
     {
-      "hrsh7th/cmp-nvim-lsp", -- LSP source for nvim-cmp, provides LSP-based completions.
-      event = "InsertEnter", 
-    },
-    {
-      "hrsh7th/cmp-emoji", -- Emoji completion source for nvim-cmp.
-      event = "InsertEnter",  
-    },
-    {
-      "hrsh7th/cmp-buffer", -- Provides completion items from the current buffer.
-      event = "InsertEnter", 
-    },
-    {
-      "hrsh7th/cmp-path", -- Path completion source, offers filesystem path completions.
-      event = "InsertEnter",  
-    },
-    {
-      "hrsh7th/cmp-cmdline", -- Provides command line completion in Neovim's command mode.
-      event = "InsertEnter",  
-    },
-    {
-      "saadparwaiz1/cmp_luasnip", -- Integrates LuaSnip snippets into nvim-cmp completions.
-      event = "InsertEnter",  
-    },
-    {
-      "L3MON4D3/LuaSnip", -- Snippet engine, allows inserting predefined code blocks.
-      event = "InsertEnter",  
-      dependencies = {"rafamadriz/friendly-snippets"}, -- Collection of snippets for various programming languages.
-    },
-    {
-      "hrsh7th/cmp-nvim-lua", -- Provides Neovim Lua API completions.
-      -- This plugin is always loaded, no specific event required.
+      "L3MON4D3/LuaSnip",
+      build = (function()
+        -- Some LuaSnip features depend on jsregexp. Only try to compile it when the
+        -- toolchain is available so we do not break install on minimal systems.
+        if vim.fn.executable "make" == 1 then
+          return "make install_jsregexp"
+        end
+      end)(),
+      dependencies = {
+        "rafamadriz/friendly-snippets",
+      },
     },
   },
 }
 
--- Configuration function for nvim-cmp
 function M.config()
-  local cmp = require "cmp" --modules stored in variables so I can use their functionality within the configuration file
+  local cmp = require "cmp"
   local luasnip = require "luasnip"
-  require("luasnip/loaders/from_vscode").lazy_load() -- lazy loads snippets from VS-Code compatible snippets
 
-  --vim.api.nvim_set_hl(0, "CmpItemKindCopilot", { fg = "#6CC644" }) -- sets foreground color for Co-Piolot
-  vim.api.nvim_set_hl(0, "CmpItemKindTabnine", { fg = "#CA42F0" })
+  luasnip.config.setup {
+    history = true,
+    updateevents = "TextChanged,TextChangedI",
+  }
+  require("luasnip.loaders.from_vscode").lazy_load()
+
   vim.api.nvim_set_hl(0, "CmpItemKindEmoji", { fg = "#FDE030" })
--- Defines a function to check if the character before the cursor is a space or if the cursor is at the beginning of the line.
---So clicking tab will take you into next piece of snippet while navigating snippet. Does more than that but enables powerful intuitive features.
-  local check_backspace = function()
-    local col = vim.fn.col "."-1 -- Gets the cursor's column position in the current line and subtracts one to check the character before the cursor. 
-    return col == 0 or vim.fn.getline("."):sub(col, col):match "%s" --True if cursor is at start of the line (col == 0) or the character before cursor is a whitespace (match "%s"). 
-  end
 
--- Above function check is commonly used in autocompletion setups to decide whether to show completions or expand snippets based on the context at the cursor position.
+  local function has_words_before()
+    local line, col = table.unpack(vim.api.nvim_win_get_cursor(0))
+    if col == 0 then
+      return false
+    end
+
+    local current_line = vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1] or ""
+    local previous_char = current_line:sub(col, col)
+    return previous_char:match "%s" == nil
+  end
 
   local icons = require "user.core.icons"
 
-  cmp.setup {-- configures nvim-cmp to use LuaSnip for snippet expansion
+  cmp.setup {
     snippet = {
       expand = function(args)
-        luasnip.lsp_expand(args.body) -- For `luasnip` users.
+        luasnip.lsp_expand(args.body)
       end,
     },
-    mapping = cmp.mapping.preset.insert { -- assigns below actions to keyboard
-      ["<C-k>"] = cmp.mapping(cmp.mapping.select_prev_item(), { "i", "c" }), -- navigating drop-down menu
-      ["<C-j>"] = cmp.mapping(cmp.mapping.select_next_item(), { "i", "c" }),
-      ["<Down>"] = cmp.mapping(cmp.mapping.select_next_item(), { "i", "c" }),
-      ["<Up>"] = cmp.mapping(cmp.mapping.select_prev_item(), { "i", "c" }),
-      ["<C-b>"] = cmp.mapping(cmp.mapping.scroll_docs(-1), { "i", "c" }), -- enables scrolling of menu
-      ["<C-f>"] = cmp.mapping(cmp.mapping.scroll_docs(1), { "i", "c" }),
-      ["<C-Space>"] = cmp.mapping(cmp.mapping.complete(), { "i", "c" }), -- see all comletions without typing
-      ["<C-e>"] = cmp.mapping {
-        i = cmp.mapping.abort(),
-        c = cmp.mapping.close(),
-      },
-      -- Accept currently selected item. If none selected, `select` first item.
-      -- Set `select` to `false` to only confirm explicitly selected items.
-      ["<CR>"] = cmp.mapping.confirm { select = true }, -- confirm selection and make window disapear
-      ["<Tab>"] = cmp.mapping(function(fallback) -- super tab power
+    mapping = cmp.mapping.preset.insert {
+      ["<C-k>"] = cmp.mapping.select_prev_item(),
+      ["<C-j>"] = cmp.mapping.select_next_item(),
+      ["<Down>"] = cmp.mapping.select_next_item(),
+      ["<Up>"] = cmp.mapping.select_prev_item(),
+      ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+      ["<C-f>"] = cmp.mapping.scroll_docs(4),
+      ["<C-Space>"] = cmp.mapping.complete(),
+      ["<C-e>"] = cmp.mapping.abort(),
+      ["<CR>"] = cmp.mapping.confirm { select = true },
+      ["<Tab>"] = cmp.mapping(function(fallback)
         if cmp.visible() then
-          cmp.select_next_item() -- if menu is visible then select next item in menu
-        elseif luasnip.expandable() then -- if a snippet is expandable then expand it
-          luasnip.expand()
-        elseif luasnip.expand_or_jumpable() then -- if also jumpable, then jump
+          cmp.select_next_item()
+        elseif luasnip.expand_or_jumpable() then
           luasnip.expand_or_jump()
-        elseif check_backspace() then -- make backspace like a tab to go backwards
-          fallback()
-          -- require("neotab").tabout()
+        elseif has_words_before() then
+          cmp.complete()
         else
           fallback()
-          -- require("neotab").tabout()
         end
-      end, { -- makes mappings usable in the insert and select mode
-        "i",
-        "s",
-      }),
+      end, { "i", "s" }),
       ["<S-Tab>"] = cmp.mapping(function(fallback)
         if cmp.visible() then
           cmp.select_prev_item()
@@ -109,20 +85,17 @@ function M.config()
         else
           fallback()
         end
-      end, {
-        "i",
-        "s",
-      }),
+      end, { "i", "s" }),
     },
-    formatting = { -- how should completion items be displayed
+    formatting = {
       fields = { "kind", "abbr", "menu" },
       format = function(entry, vim_item)
-        vim_item.kind = icons.kind[vim_item.kind]
+        vim_item.kind = icons.kind[vim_item.kind] or vim_item.kind
         vim_item.menu = ({
           nvim_lsp = "[LSP]",
-          nvim_lua = "LUA]",
-          luasnip = "[LuaSnip",
-          buffer = "[File]",
+          nvim_lua = "[Lua]",
+          luasnip = "[Snippet]",
+          buffer = "[Buffer]",
           path = "[Path]",
           emoji = "[Emoji]",
         })[entry.source.name]
@@ -132,23 +105,15 @@ function M.config()
           vim_item.kind_hl_group = "CmpItemKindEmoji"
         end
 
-        if entry.source.name == "cmp_tabnine" then
-          vim_item.kind = icons.misc.Robot
-          vim_item.kind_hl_group = "CmpItemKindTabnine"
-        end
-
         return vim_item
       end,
     },
-    sources = { -- Where should completion items come from
-      --{ name = "copilot" },
+    sources = cmp.config.sources {
       { name = "nvim_lsp" },
       { name = "luasnip" },
-      { name = "cmp_tabnine" },
       { name = "nvim_lua" },
       { name = "buffer" },
       { name = "path" },
-      { name = "calc" },
       { name = "emoji" },
     },
     confirm_opts = {
@@ -156,18 +121,36 @@ function M.config()
       select = false,
     },
     window = {
-      completion = {
-        border = "rounded",
+      completion = cmp.config.window.bordered {
         scrollbar = false,
       },
-      documentation = {
-        border = "rounded",
-      },
+      documentation = cmp.config.window.bordered(),
     },
     experimental = {
       ghost_text = false,
     },
   }
+
+  cmp.setup.cmdline({ "/", "?" }, {
+    mapping = cmp.mapping.preset.cmdline(),
+    sources = {
+      { name = "buffer" },
+    },
+  })
+
+  cmp.setup.cmdline(":", {
+    mapping = cmp.mapping.preset.cmdline(),
+    sources = cmp.config.sources({
+      { name = "path" },
+    }, {
+      { name = "cmdline" },
+    }),
+  })
+
+  local autopairs_loaded, cmp_autopairs = pcall(require, "nvim-autopairs.completion.cmp")
+  if autopairs_loaded then
+    cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
+  end
 end
 
 return M


### PR DESCRIPTION
## Summary
- modernize the nvim-cmp plugin spec and align dependencies with the configured sources
- update LuaSnip loading and completion mappings to match current nvim-cmp behaviour
- wire cmp confirm events into nvim-autopairs and enable command-line completion support

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0943b0e04832e94b6406fb7326b3a