### PR TITLE
Update lualine theme to Tokyonight

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/lualine.lua
+++ b/private_dot_config/nvim/lua/user/plugins/lualine.lua
@@ -3,14 +3,19 @@ local M = {
 }
 
 function M.config()
+  -- Configure the statusline provided by lualine to match the rest of the UI.
   require("lualine").setup {
     options = {
+      -- Remove decorative separators so the statusline stays minimal.
       component_separators = { left = "", right = "" },
       section_separators = { left = "", right = "" },
+      -- Keep the tree explorer from stealing focus-based highlights.
       ignore_focus = { "NvimTree" },
-      theme = 'iceberg_dark'
+      -- Use the Tokyonight palette so the statusline matches the global colorscheme.
+      theme = "tokyonight",
     },
     sections = {
+      -- Only show git info, diagnostics, filetype, and progress for a concise layout.
       lualine_a = {},
       lualine_b = { "branch" },
       lualine_c = { "diagnostics" },
@@ -18,6 +23,7 @@ function M.config()
       lualine_y = { "progress" },
       lualine_z = {},
     },
+    -- Enable useful extensions for common tools like quickfix lists and Git status buffers.
     extensions = { "quickfix", "man", "fugitive" },
   }
 end


### PR DESCRIPTION
## Summary
- switch the lualine statusline theme to Tokyonight to match the rest of the UI
- add inline comments describing the statusline configuration choices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e17844867c832eaa1d93068b013e5a