### PR TITLE
Enhance todo-comments configuration

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/todo_comments.lua
+++ b/private_dot_config/nvim/lua/user/plugins/todo_comments.lua
@@ -1,12 +1,69 @@
+---@type LazySpec
 local M = {
+  -- Plugin that highlights and searches TODO, HACK, WARN, etc. comments in code.
   "folke/todo-comments.nvim",
-  dependencies = { "nvim-lua/plenary.nvim" },
+  dependencies = {
+    -- Required dependency that powers asynchronous helpers for todo-comments.
+    "nvim-lua/plenary.nvim",
+  },
+  -- Load the plugin only after Neovim finishes starting up to avoid slowing boot time.
   event = "VeryLazy",
   opts = {
-    -- your configuration comes here
-    -- or leave it empty to use the default settings
-    -- refer to the configuration section below
-  }
+    -- Controls whether signs (icons in the gutter) are enabled.
+    signs = true,
+    -- Determine the priority of the signs so they do not clash with diagnostics.
+    sign_priority = 8,
+    keywords = {
+      -- Customize icon/color/alternative keywords for each type of annotation.
+      FIX = {
+        icon = " ",
+        color = "error",
+        alt = { "FIXME", "BUG", "FIXIT", "ISSUE" },
+      },
+      TODO = {
+        icon = " ",
+        color = "info",
+      },
+      HACK = {
+        icon = " ",
+        color = "warning",
+      },
+      WARN = {
+        icon = " ",
+        color = "warning",
+        alt = { "WARNING", "XXX" },
+      },
+      PERF = {
+        icon = " ",
+        color = "hint",
+        alt = { "OPTIM", "PERFORMANCE", "OPTIMIZE" },
+      },
+      NOTE = {
+        icon = " ",
+        color = "hint",
+        alt = { "INFO" },
+      },
+    },
+    highlight = {
+      -- Highlight style for text before the keyword.
+      before = "fg",
+      -- Highlight style for the keyword itself.
+      keyword = "wide",
+      -- Highlight style for text after the keyword.
+      after = "fg",
+    },
+    search = {
+      -- Use ripgrep to locate todo comments quickly across the project.
+      command = "rg",
+      args = {
+        "--color=never",
+        "--no-heading",
+        "--with-filename",
+        "--line-number",
+        "--column",
+      },
+    },
+  },
 }
 
 return M


### PR DESCRIPTION
## Summary
- add descriptive annotations explaining the todo-comments plugin setup
- expand the todo-comments configuration with customized keywords, highlights, and search defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e17a0d1c2c832ea7e97448d953aae1