### PR TITLE
Configure hardtime.nvim behavior

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/hardtime.lua
+++ b/private_dot_config/nvim/lua/user/plugins/hardtime.lua
@@ -1,8 +1,30 @@
 local M = {
-   "m4xshen/hardtime.nvim",
-   dependencies = { "MunifTanjim/nui.nvim" },
-   event = "VeryLazy",
-   opts = {}
+  "m4xshen/hardtime.nvim",
+  dependencies = { "MunifTanjim/nui.nvim" },
+  event = "VeryLazy",
+  -- Encourage practicing efficient navigation while avoiding disruption in special buffers.
+  opts = {
+    disable_mouse = false,
+    disabled_filetypes = {
+      "neo-tree",
+      "lazy",
+      "mason",
+      "help",
+      "qf",
+      "TelescopePrompt",
+    },
+    restriction_mode = "hint",
+    restricted_keys = {
+      ["h"] = { "n", "x" },
+      ["j"] = { "n", "x" },
+      ["k"] = { "n", "x" },
+      ["l"] = { "n", "x" },
+      ["-"] = { "n", "x" },
+      ["+"] = { "n", "x" },
+      ["gj"] = { "n", "x" },
+      ["gk"] = { "n", "x" },
+    },
+  },
 }
 
 return M


### PR DESCRIPTION
## Summary
- add contextual configuration for the hardtime.nvim plugin
- disable the plugin in special-purpose buffers and adjust restricted keys
- enable hint-based restriction mode to encourage efficient navigation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e17bf8d41c832eb95efa28c77beb21