### PR TITLE
Annotate and modernize Mason setup

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/mason.lua
+++ b/private_dot_config/nvim/lua/user/plugins/mason.lua
@@ -1,11 +1,14 @@
---NOTE: mason.nvim is a Neovim plugin that allows you to easily manage external editor tooling such as LSP servers, DAP servers, linters, and formatters through a single interface.
--- Mason is basically the menu you see when a plugin gets installed now.
+--[[
+  mason.nvim is a Neovim plugin that allows you to easily manage external editor tooling such as
+  LSP servers, DAP servers, linters, and formatters through a single interface. Mason is basically
+  the menu you see when a plugin gets installed now.
 
---NOTE:mason-lspconfig.nvim closes some gaps that exist between mason.nvim and lspconfig. Its main responsibilities are to:
---register a setup hook with lspconfig that ensures servers installed with mason.nvim are set up with the necessary configuration
---provide extra convenience APIs such as the :LspInstall command
---allow you to (i) automatically install, and (ii) automatically set up a predefined list of servers
---translate between lspconfig server names and mason.nvim package names (e.g. lua_ls <-> lua-language-server)
+  mason-lspconfig.nvim closes the gap between mason.nvim and lspconfig. Its main responsibilities are to:
+    * register a setup hook with lspconfig that ensures servers installed with mason.nvim are configured
+    * provide extra convenience APIs such as the :LspInstall command
+    * allow you to (i) automatically install, and (ii) automatically set up a predefined list of servers
+    * translate between lspconfig server names and mason.nvim package names (e.g. lua_ls <-> lua-language-server)
+]]
 local M = {
   "williamboman/mason-lspconfig.nvim",
   dependencies = {
@@ -13,8 +16,9 @@ local M = {
   },
 }
 
-
 function M.config()
+  -- Define the language servers that should always be available. These names correspond to
+  -- the identifiers used by `nvim-lspconfig`.
   local servers = {
     "lua_ls",
     "pyright",
@@ -22,14 +26,29 @@ function M.config()
     "jsonls",
   }
 
+  -- mason.nvim handles installing and updating the external tooling. Modern versions expose
+  -- additional quality-of-life options such as upgrading `pip` automatically and customizing
+  -- the UI icons, so we take advantage of them here.
   require("mason").setup {
     ui = {
       border = "rounded",
+      icons = {
+        package_installed = "",
+        package_pending = "",
+        package_uninstalled = "",
+      },
+    },
+    pip = {
+      upgrade_pip = true,
     },
   }
 
+  -- mason-lspconfig bridges mason.nvim with nvim-lspconfig. Ensuring the servers above are
+  -- installed keeps the tooling up-to-date, while `automatic_installation` makes any servers
+  -- configured elsewhere in your setup install themselves the first time they are needed.
   require("mason-lspconfig").setup {
     ensure_installed = servers,
+    automatic_installation = true,
   }
 end
 


### PR DESCRIPTION
## Summary
- add descriptive annotations to the Mason configuration for clarity
- customize Mason's UI and enable automatic pip upgrades for smoother package management
- allow mason-lspconfig to automatically install configured LSP servers

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1868812ec832eb0a077467f681f00