### PR TITLE
Update which-key configuration

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/comment.lua
+++ b/private_dot_config/nvim/lua/user/plugins/comment.lua
@@ -20,13 +20,10 @@ function M.config()
   -- comment action.  `<Plug>` mappings are used so Comment.nvim stays in
   -- control of the implementation details.
   local wk = require "which-key"
-  wk.register {
-    ["<leader>/"] = { "<Plug>(comment_toggle_linewise_current)", "Comment" },
-  }
-
-  wk.register {
-    ["<leader>/"] = { "<Plug>(comment_toggle_linewise_visual)", "Comment", mode = "v" },
-  }
+  wk.add({
+    { "<leader>/", "<Plug>(comment_toggle_linewise_current)", desc = "Comment", mode = "n" },
+    { "<leader>/", "<Plug>(comment_toggle_linewise_visual)", desc = "Comment", mode = "v" },
+  })
 
   -- Comment.nvim handles integration with ts-context-commentstring itself, so
   -- we disable the built-in autocmd and wire the hook manually below.

--- a/private_dot_config/nvim/lua/user/plugins/telescope.lua
+++ b/private_dot_config/nvim/lua/user/plugins/telescope.lua
@@ -5,17 +5,17 @@ local M = {
 
 function M.config()
   local wk = require "which-key"
-  wk.register {
-    ["<leader>bb"] = { "<cmd>Telescope buffers previewer=false<cr>", "Find" },
-    ["<leader>fb"] = { "<cmd>Telescope git_branches<cr>", "Checkout branch" },
-    ["<leader>fc"] = { "<cmd>Telescope colorscheme<cr>", "Colorscheme" },
-    ["<leader>ff"] = { "<cmd>Telescope find_files<cr>", "Find files" },
-    ["<leader>fp"] = { "<cmd>lua require('telescope').extensions.projects.projects()<cr>", "Projects" },
-    ["<leader>ft"] = { "<cmd>Telescope live_grep<cr>", "Find Text" },
-    ["<leader>fh"] = { "<cmd>Telescope help_tags<cr>", "Help" },
-    ["<leader>fl"] = { "<cmd>Telescope resume<cr>", "Last Search" },
-    ["<leader>fr"] = { "<cmd>Telescope oldfiles<cr>", "Recent File" },
-  }
+  wk.add({
+    { "<leader>bb", "<cmd>Telescope buffers previewer=false<cr>", desc = "Find" },
+    { "<leader>fb", "<cmd>Telescope git_branches<cr>", desc = "Checkout branch" },
+    { "<leader>fc", "<cmd>Telescope colorscheme<cr>", desc = "Colorscheme" },
+    { "<leader>ff", "<cmd>Telescope find_files<cr>", desc = "Find files" },
+    { "<leader>fp", "<cmd>lua require('telescope').extensions.projects.projects()<cr>", desc = "Projects" },
+    { "<leader>ft", "<cmd>Telescope live_grep<cr>", desc = "Find Text" },
+    { "<leader>fh", "<cmd>Telescope help_tags<cr>", desc = "Help" },
+    { "<leader>fl", "<cmd>Telescope resume<cr>", desc = "Last Search" },
+    { "<leader>fr", "<cmd>Telescope oldfiles<cr>", desc = "Recent File" },
+  }, { mode = "n" })
 
   local icons = require "user.core.icons"
   local actions = require "telescope.actions"

--- a/private_dot_config/nvim/lua/user/plugins/whichkey.lua
+++ b/private_dot_config/nvim/lua/user/plugins/whichkey.lua
@@ -2,6 +2,12 @@
 local M = {
   "folke/which-key.nvim",
   event = "VeryLazy",
+  dependencies = {
+    {
+      "echasnovski/mini.icons",
+      opts = {},
+    },
+  },
 }
 
 function M.config()
@@ -27,10 +33,14 @@ function M.config()
         g = false,
       },
     },
-    window = {
+    win = {
       border = "rounded",
       position = "bottom",
       padding = { 2, 2, 2, 2 },
+    },
+    triggers = {
+      { "<leader>", mode = "n" },
+      { "<leader>", mode = "v" },
     },
     show_help = false,
     show_keys = false,
@@ -44,37 +54,27 @@ function M.config()
   -- Keep the specification close to the actual keymaps defined throughout the
   -- config so the UI mirrors reality.  Each entry either describes a single
   -- mapping (with `desc`) or marks an entire prefix as a group.
-  ---@type table<string, any>
-  local normal_mode = {
-    q = { "<cmd>confirm q<CR>", desc = "Quit Neovim" },
-    h = { "<cmd>nohlsearch<CR>", desc = "Clear search highlight" },
-    [";"] = { "<cmd>tabnew | terminal<CR>", desc = "Terminal tab" },
-    v = { "<cmd>vsplit<CR>", desc = "Vertical split" },
-    w = { "<cmd>lua vim.wo.wrap = not vim.wo.wrap<CR>", desc = "Toggle wrap" },
-    a = {
-      name = "Tabs",
-      n = { "<cmd>$tabnew<CR>", desc = "New empty tab" },
-      N = { "<cmd>tabnew %<CR>", desc = "Tab from file" },
-      o = { "<cmd>tabonly<CR>", desc = "Close other tabs" },
-      h = { "<cmd>-tabmove<CR>", desc = "Move tab left" },
-      l = { "<cmd>+tabmove<CR>", desc = "Move tab right" },
-    },
-    b = { name = "Buffers" },
-    f = { name = "Find" },
-    g = { name = "Git" },
-    l = { name = "LSP" },
-    p = {
-      name = "Project",
-      d = { "<cmd>cd %:p:h<CR>", desc = "CD to buffer dir" },
-    },
-    t = { name = "Test" },
-    T = { name = "Treesitter" },
-  }
-
-  wk.register(normal_mode, {
-    mode = "n",
-    prefix = "<leader>",
-  })
+  wk.add({
+    { "<leader>q", "<cmd>confirm q<CR>", desc = "Quit Neovim" },
+    { "<leader>h", "<cmd>nohlsearch<CR>", desc = "Clear search highlight" },
+    { "<leader>;", "<cmd>tabnew | terminal<CR>", desc = "Terminal tab" },
+    { "<leader>v", "<cmd>vsplit<CR>", desc = "Vertical split" },
+    { "<leader>w", "<cmd>lua vim.wo.wrap = not vim.wo.wrap<CR>", desc = "Toggle wrap" },
+    { "<leader>a", group = "Tabs" },
+    { "<leader>an", "<cmd>$tabnew<CR>", desc = "New empty tab" },
+    { "<leader>aN", "<cmd>tabnew %<CR>", desc = "Tab from file" },
+    { "<leader>ao", "<cmd>tabonly<CR>", desc = "Close other tabs" },
+    { "<leader>ah", "<cmd>-tabmove<CR>", desc = "Move tab left" },
+    { "<leader>al", "<cmd>+tabmove<CR>", desc = "Move tab right" },
+    { "<leader>b", group = "Buffers" },
+    { "<leader>f", group = "Find" },
+    { "<leader>g", group = "Git" },
+    { "<leader>l", group = "LSP" },
+    { "<leader>p", group = "Project" },
+    { "<leader>pd", "<cmd>cd %:p:h<CR>", desc = "CD to buffer dir" },
+    { "<leader>t", group = "Test" },
+    { "<leader>T", group = "Treesitter" },
+  }, { mode = "n" })
 end
 
 return M


### PR DESCRIPTION
## Summary
- migrate which-key registration calls to the new `wk.add` spec for leader mappings
- add mini.icons support, update deprecated window options, and limit triggers to leader keys to silence warnings

## Testing
- nvim --headless "+quit" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1895e1194832eb838bc8bebec3add