### PR TITLE
Set default Nerd Font for Nerdy picker

### DIFF
--- a/private_dot_config/nvim/init.lua
+++ b/private_dot_config/nvim/init.lua
@@ -14,9 +14,10 @@ lazy_helper.spec "user.plugins.devicons"
 lazy_helper.spec "user.plugins.todo_comments"
 lazy_helper.spec "user.plugins.hardtime"
 lazy_helper.spec "user.plugins.whichkey"
-lazy_helper.spec "user.plugins.lspconfig" -- may not be needed at all now
+lazy_helper.spec "user.plugins.lspconfig"
 lazy_helper.spec "user.plugins.mason"
 -- lazy_helper.spec "user.plugins.none-ls"
+-- Nerd Font picker powered by Telescope / Nerdy.nvim.
 lazy_helper.spec "user.plugins.nerdy"
 lazy_helper.spec "user.plugins.treesitter"
 -- lazy_helper.spec "user.plugins.telescope"

--- a/private_dot_config/nvim/lua/user/plugins/nerdy.lua
+++ b/private_dot_config/nvim/lua/user/plugins/nerdy.lua
@@ -1,10 +1,31 @@
+---@type LazySpec
 local M = {
+  -- Plugin providing Telescope picker to browse Nerd Font icons.
   "2KAbhishek/nerdy.nvim",
   dependencies = {
-    'stevearc/dressing.nvim',
-  'nvim-telescope/telescope.nvim'
+    -- Fancy UI enhancements for picker prompts.
+    "stevearc/dressing.nvim",
+    -- Nerdy piggybacks on Telescope for its picker UI.
+    "nvim-telescope/telescope.nvim",
   },
-  cmd = 'Nerdy'
+  -- Load plugin only for the :Nerdy command or defined keymaps.
+  cmd = "Nerdy",
+  keys = {
+    {
+      "<leader>fn",
+      "<cmd>Nerdy<CR>",
+      desc = "Find Nerd Font icon",
+    },
+  },
+  config = function()
+    -- Fall back to JetBrainsMono if no user preference is provided.
+    local preferred_font = vim.g.preferred_nerd_font or vim.env.NERD_FONT or "JetBrainsMono Nerd Font"
+
+    require("nerdy").setup {
+      -- Limit picker entries to a single Nerd Font family for consistent glyphs.
+      nerd_font = preferred_font,
+    }
+  end,
 }
 
 return M


### PR DESCRIPTION
## Summary
- remove the outdated lspconfig comment in the Neovim init file
- configure Nerdy.nvim to default to JetBrainsMono Nerd Font while still honoring user overrides via globals or env vars

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1aa2c57f4832e9f8286b78b0b3d71