### PR TITLE
Modernize none-ls configuration

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/none-ls.lua
+++ b/private_dot_config/nvim/lua/user/plugins/none-ls.lua
@@ -1,57 +1,90 @@
---NOTE: Neovim doesn't provide a way for non-LSP sources to hook into its LSP client. null-ls is an attempt to bridge that gap and simplify the process of creating, sharing, and setting up LSP sources using pure Lua.
+--- @file none-ls.lua
+--- @brief Configure the `nvimtools/none-ls.nvim` plugin to expose external
+--- formatters and linters through Neovim's built-in LSP client.
 local M = {
   "nvimtools/none-ls.nvim",
   dependencies = {
-    "nvim-lua/plenary.nvim"
-  }
+    "nvim-lua/plenary.nvim", -- Required runtime dependency for none-ls
+  },
+  event = { "BufReadPre", "BufNewFile" }, -- Lazily load when editing files
 }
 
 function M.config()
+  ---@type table<string, any>
   local null_ls = require "null-ls"
 
-  -- local formatting = null_ls.builtins.formatting
-  -- local diagnostics = null_ls.builtins.diagnostics
+  -- Extract helpers for readability and to avoid repeating `null_ls.builtins`
+  local formatting = null_ls.builtins.formatting
   local diagnostics = null_ls.builtins.diagnostics
-  -- local actions = null_ls.builtins.code_actions
+  local code_actions = null_ls.builtins.code_actions
+  local utils = require "null-ls.utils"
+
+  ---Create a convenience wrapper that keeps a source inactive when its backing
+  ---executable is not available on the system. This prevents none-ls from
+  ---spamming errors when a formatter/linter is missing.
+  ---@param source null-ls.Source
+  ---@param command string|nil
+  local function with_executable(source, command)
+    return source.with {
+      condition = function()
+        return utils.is_executable(command or source._opts.command)
+      end,
+    }
+  end
+
+  ---Restrict a source to projects that provide explicit configuration files.
+  ---This keeps formatters like Stylua or Prettier from running on arbitrary
+  ---projects that may not expect them.
+  ---@param source null-ls.Source
+  ---@param files string|string[]
+  local function with_root_file(source, files)
+    return source.with {
+      condition = function()
+        return utils.root_has_file(files)
+      end,
+    }
+  end
+
+  local sources = {
+    -- Lua formatting only when a Stylua config is present
+    with_root_file(formatting.stylua, { "stylua.toml", ".stylua.toml" }),
+
+    -- JavaScript/TypeScript formatting using Prettierd when installed
+    with_executable(formatting.prettierd, "prettierd"),
+
+    -- Python formatters/linters (require the binaries in your PATH)
+    with_executable(formatting.black.with { extra_args = { "--fast" } }, "black"),
+    with_executable(formatting.isort, "isort"),
+    with_executable(diagnostics.flake8, "flake8"),
+
+    -- Shell integration
+    with_executable(formatting.shfmt.with { extra_args = { "-i", "2", "-ci" } }, "shfmt"),
+    with_executable(diagnostics.shellcheck, "shellcheck"),
+
+    -- Git aware code actions (requires gitsigns dependency to be useful)
+    code_actions.gitsigns,
+  }
+
+  local formatting_augroup = vim.api.nvim_create_augroup("NoneLsFormatting", { clear = true })
 
   null_ls.setup {
-    debug = true,
-    sources = {
-      -- Lua
-      null_ls.builtins.formatting.stylua, -- Add formatters and linters
-      --formatting.prettier,
-      -- formatting.prettier.with {
-      --   extra_filetypes = { "toml" },
-      --   -- extra_args = { "--no-semi", "--single-quote", "--jsx-single-quote" },
-      -- },
-      -- formatting.eslint,
-      -- null_ls.builtins.diagnostics.flake8,
-      -- Python 
-      -- null_ls.builtins.formatting.black.with({
-      --   extra_args = {"--fast"},
-      --   filetypes = {"python"}
-      -- }),
-      -- diagnostics.flake8, -- python linter
-      -- null_ls.builtins.completion.spell,
-
-      -- Shell 
-      --actions.shellcheck, -- Linter aka check for errors/warnings 
-      --diagnostics.shellcheck,
-      --formatting.shfmt, -- shell formatter, parser, and interpreter
-
-      -- C++
-      -- diagnostics.cppcheck, -- Can make really cool setups with this
--- C++ Formatting
-      --formatting.clang_format.with({
-      --    filetypes = { "cpp" },  -- Ensure it's applied to these languages
-      --    extra_args = { "--style=Google" },  -- Customize your format style (Google, LLVM, Mozilla, etc.)
-      --}),
-
-      ----formatting.clang_format, -- Tool to format C/C++. Comes automatically with clangd from what I understand.
-      ---- CMake 
-      --diagnostics.cmake_lint,
-      --formatting.cmake_format,
-    },
+    debug = false, -- Enable for verbose logging if you need to troubleshoot
+    sources = sources,
+    on_attach = function(client, bufnr)
+      -- Register a buffer-local format-on-save autocmd whenever the source
+      -- advertises the formatting capability.
+      if client.supports_method "textDocument/formatting" then
+        vim.api.nvim_clear_autocmds { group = formatting_augroup, buffer = bufnr }
+        vim.api.nvim_create_autocmd("BufWritePre", {
+          group = formatting_augroup,
+          buffer = bufnr,
+          callback = function()
+            vim.lsp.buf.format { bufnr = bufnr, async = false }
+          end,
+          desc = "Format with none-ls before saving the buffer",
+        })
+      end
+    end,
   }
 end
 


### PR DESCRIPTION
## Summary
- migrate the none-ls plugin spec to lazily load and reuse helper utilities
- gate formatters and linters behind executable/root checks to avoid runtime errors
- document the configuration and enable format-on-save integration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b09b3268832e95e07cd6dfb9de45