### PR TITLE
Fix Treesitter stable branch config

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/treesitter.lua
+++ b/private_dot_config/nvim/lua/user/plugins/treesitter.lua
@@ -23,8 +23,8 @@
 ---@type LazyPluginSpec
 local M = {
   "nvim-treesitter/nvim-treesitter",
-  branch="main",
-  event = { "BufReadPost", "BufNewFile" },
+  branch = "master",
+  lazy = false,
   build = ":TSUpdate",
 }
 


### PR DESCRIPTION
## Summary
- Switch `nvim-treesitter` from `main` to `master` for compatibility with the existing `nvim-treesitter.configs` setup API.
- Disable lazy-loading with `lazy = false`.
- Keep the existing parser list, highlighting, indentation, incremental selection, and large-file guard unchanged.

## Why
The current config uses the new Treesitter `main` branch while still calling the older `require("nvim-treesitter.configs").setup(...)` API. Using the stable `master` branch keeps the current config working until a later migration to the new Treesitter API.

## After merging
Run:

```vim
:Lazy sync
:TSUpdate
:checkhealth nvim-treesitter
```