### PR TITLE
Disable Treesitter provider in vim-illuminate

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/illuminate.lua
+++ b/private_dot_config/nvim/lua/user/plugins/illuminate.lua
@@ -10,8 +10,9 @@ function M.config()
   local illuminate = require("illuminate")
 
   illuminate.configure {
-    -- Try LSP-powered references first, fall back to Treesitter, then plain text.
-    providers = { "lsp", "treesitter", "regex" },
+    -- Try LSP-powered references first, then fall back to plain text.
+    -- The Treesitter provider is disabled to avoid crashes in nvim-treesitter locals.
+    providers = { "lsp", "regex" },
 
     -- A small delay keeps the highlights from flashing while you move quickly.
     delay = 150,


### PR DESCRIPTION
## Summary
- Remove the `treesitter` provider from `vim-illuminate`.
- Keep `lsp` as the first provider and `regex` as the fallback.
- Update the provider comment to explain why Treesitter is disabled for illuminate.

## Why
Opening files can trigger an internal `vim-illuminate` error through `nvim-treesitter/locals.lua`:

```text
attempt to call method 'parent' (a nil value)
```

Disabling only the illuminate Treesitter provider avoids that crash path while preserving Treesitter for highlighting, indentation, parser support, and other Neovim features.

## After merging
Restart Neovim or run:

```vim
:Lazy reload vim-illuminate
```