### PR TITLE
Fix Vue Treesitter indentation crash

### DIFF
--- a/private_dot_config/nvim/lua/user/plugins/indentline.lua
+++ b/private_dot_config/nvim/lua/user/plugins/indentline.lua
@@ -23,16 +23,17 @@ function M.config()
       "Trouble",
       "text",
     },
-    -- Use a thin vertical line for both regular and context guides.
+    -- Use a thin vertical line for regular indent guides.
     char = icons.ui.LineMiddle,
     context_char = icons.ui.LineMiddle,
     -- Hide visual clutter while still keeping the first indent visible.
     show_trailing_blankline_indent = false,
     show_first_indent_level = true,
-    -- Rely on Treesitter to detect scope boundaries and highlight them.
-    use_treesitter = true,
-    show_current_context = true,
-    show_current_context_start = true,
+    -- Avoid Treesitter-backed scope detection here. Mixed-language files such
+    -- as Vue can trigger nvim-treesitter indent/query predicate crashes.
+    use_treesitter = false,
+    show_current_context = false,
+    show_current_context_start = false,
   }
 
   -- Allow quickly toggling guides when the extra detail is distracting.

--- a/private_dot_config/nvim/lua/user/plugins/treesitter.lua
+++ b/private_dot_config/nvim/lua/user/plugins/treesitter.lua
@@ -80,9 +80,13 @@ function M.config()
     },
 
     -- Indentation (parser-specific; falls back gracefully where unsupported)
+    -- Vue indentation is disabled because its mixed-language queries can crash
+    -- through nvim-treesitter indent/query predicates while editing .vue files.
     indent = {
       enable = true,
-      disable = function(lang, buf) return too_large(lang, buf) end,
+      disable = function(lang, buf)
+        return lang == "vue" or too_large(lang, buf)
+      end,
     },
 
     -- Incremental selection (super handy for refactors)


### PR DESCRIPTION
## Summary
- Disable Treesitter-powered indentation for Vue buffers.
- Disable Treesitter-backed scope/context detection in `indent-blankline`.
- Keep Treesitter highlighting, parsers, incremental selection, and regular indent guides enabled.

## Why
Editing `.vue` files can trigger this stack:

```text
nvim-treesitter/query_predicates.lua:106: attempt to call method 'type' (a nil value)
nvim-treesitter/indent.lua
indent-blankline.nvim
```

The crash path is Treesitter indentation/context detection, especially in mixed-language Vue files. This change avoids that brittle path without removing Treesitter entirely.

## After merging
Run:

```vim
:Lazy sync
:TSUpdate
```

Then restart Neovim and reopen the `.vue` file.